### PR TITLE
Salom qalesan greeting

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
          FAQ, Breadcrumbs, ItemList)
          ========================================================= -->
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover, user-scalable=no" />
 
     <!-- ===== Search engine verifications ===== -->
     <meta name="google-site-verification" content="VK7JXvF3PEEQqXpbhVC8AdzmqUaQdApPv_vDu6KFhxA" />

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -110,6 +110,7 @@ body {
 
 html {
   background: transparent !important;
+  -webkit-text-size-adjust: 100%;
 }
 
 /**
@@ -168,6 +169,21 @@ html {
 
 html {
   font-size: var(--font-size);
+}
+
+/* Prevent iOS Safari from auto-zooming inputs on focus by ensuring
+   form controls use at least 16px font-size on iOS devices */
+@supports (-webkit-touch-callout: none) {
+  input[type="text"],
+  input[type="tel"],
+  input[type="email"],
+  input[type="number"],
+  input[type="search"],
+  input[type="password"],
+  textarea,
+  select {
+    font-size: 16px !important;
+  }
 }
 
 


### PR DESCRIPTION
Prevent iOS Safari from auto-zooming on input focus to improve mobile user experience.

iOS Safari automatically zooms the page when a user taps on an input field with a font size smaller than 16px. This PR addresses this by setting `maximum-scale=1` and `user-scalable=no` in the viewport meta tag and ensuring form controls have a minimum font size of 16px on iOS devices.

---
<a href="https://cursor.com/background-agent?bcId=bc-ce8ca697-9e01-4dd7-ba13-dde618889270">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ce8ca697-9e01-4dd7-ba13-dde618889270">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

